### PR TITLE
Install library and export target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,16 +19,16 @@ option_with_default(CMAKE_BUILD_TYPE "Build type (Release or Debug)" Release)
 #option_with_default(PYMOD_INSTALL_LIBDIR "Location within CMAKE_INSTALL_LIBDIR to which python modules are installed" /)
 #option_with_default(ENABLE_GENERIC "Enables mostly static linking of system libraries for shared library" OFF)
 option_with_default(gau2grid_CXX_STANDARD "Specify C++ standard for core gau2grid" 11)
+option_with_default(ENABLE_PYTHON_BINDINGS "Enables pybind11 interface to C++ library" OFF)
 
 ########################  Process & Validate Options  ##########################
-#include(GNUInstallDirs)
 include(autocmake_safeguards)
 include(custom_color_messages)
 
-#if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-#    set(CMAKE_INSTALL_PREFIX "/usr/local/gau2grid" CACHE PATH "Install path" FORCE)
-#endif()
-#message(STATUS "gau2grid install: ${CMAKE_INSTALL_PREFIX}")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "/usr/local/gau2grid" CACHE PATH "Install path" FORCE)
+endif()
+message(STATUS "gau2grid install: ${CMAKE_INSTALL_PREFIX}")
 
 set(CMAKE_CXX_STANDARD "${gau2grid_CXX_STANDARD}")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -62,12 +62,46 @@ set(sources_list ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_phi.cc
                  ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_spherical.cc
                  ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_helper.cc)
 
+add_library(gg ${sources_list})
 
-add_library(gau2grid ${sources_list})
+if(${ENABLE_PYTHON_BINDINGS})
+    #list(APPEND sources_list ${CMAKE_CURRENT_BINARY_DIR}/pygg_core.cc)
+    pybind11_add_module(pygg_core NO_EXTRAS ${CMAKE_CURRENT_BINARY_DIR}/pygg_core.cc)
+    target_link_libraries(pygg_core PRIVATE gg)
+    target_link_libraries(pygg_core PUBLIC pybind11::module)
+endif()
 
-list(APPEND sources_list ${CMAKE_CURRENT_BINARY_DIR}/pygg_core.cc)
+###################################  Install  ##################################
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
-pybind11_add_module(pygg_core NO_EXTRAS ${sources_list})
-target_link_libraries(pygg_core PRIVATE gau2grid)
-target_link_libraries(pygg_core PUBLIC pybind11::module)
+set(PN ${PROJECT_NAME})
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gau2grid.h
+              DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PN})
+
+install(TARGETS gg
+        EXPORT "${PN}Targets"
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+#target_compile_definitions(efp INTERFACE USING_${PN})
+target_include_directories(gg INTERFACE
+                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
+set(CMAKECONFIG_INSTALL_DIR "share/cmake/${PN}")
+configure_package_config_file(cmake/${PN}Config.cmake.in
+                              "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
+                              INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
+                                 VERSION ${${PN}_VERSION}
+                                 COMPATIBILITY AnyNewerVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
+#              cmake/FindTargetLAPACK.cmake
+        DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+install(EXPORT "${PN}Targets"
+        NAMESPACE "${PN}::"
+        DESTINATION ${CMAKECONFIG_INSTALL_DIR})
 

--- a/cmake/gau2gridConfig.cmake.in
+++ b/cmake/gau2gridConfig.cmake.in
@@ -1,0 +1,88 @@
+# gau2gridConfig.cmake
+# --------------------
+#
+# GAU2GRID cmake module.
+# This module sets the following variables in your project::
+#
+#   gau2grid_FOUND - true if gau2grid and all required components found on the system
+#   gau2grid_VERSION - gau2grid version in format Major.Minor.Release
+#   gau2grid_INCLUDE_DIRS - Directory where gau2grid header is located.
+#   gau2grid_INCLUDE_DIR - same as DIRS
+##   gau2grid_DEFINITIONS - Definitions necessary to use gau2grid, namely USING_gau2grid.
+#   gau2grid_LIBRARIES - gau2grid library to link against.
+#   gau2grid_LIBRARY - same as LIBRARIES
+#
+#
+## Available components: shared static ::
+##
+##   shared - search for only shared library
+##   static - search for only static library
+#
+#
+# Exported targets::
+#
+# If gau2grid is found, this module defines the following :prop_tgt:`IMPORTED`
+# target. Target is shared _or_ static, so, for both, use separate, not
+# overlapping, installations. ::
+#
+#   gau2grid::gg - the main gau2grid library with header & defs attached.
+#
+#
+# Suggested usage::
+#
+#   find_package(gau2grid)
+##   find_package(libefp 1.5.0 EXACT CONFIG REQUIRED COMPONENTS shared)
+#
+#
+# The following variables can be set to guide the search for this package::
+#
+#   gau2grid_DIR - CMake variable, set to directory containing this Config file
+#   CMAKE_PREFIX_PATH - CMake variable, set to root directory of this package
+##   PATH - environment variable, set to bin directory of this package
+#   CMAKE_DISABLE_FIND_PACKAGE_gau2grid - CMake variable, disables
+#     find_package(gau2grid) when not REQUIRED, perhaps to force internal build
+
+@PACKAGE_INIT@
+
+set(PN gau2grid)
+set (_valid_components
+    static
+    shared
+)
+
+#if(${BUILD_SHARED_LIBS})
+#    set(${PN}_shared_FOUND 1)
+#else()
+#    set(${PN}_static_FOUND 1)
+#endif()
+#
+#set(${PN}_DEFINITIONS USING_${PN})
+
+check_required_components(${PN})
+
+## make detectable the FindTarget*.cmake modules
+#list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+#-----------------------------------------------------------------------------
+# Don't include targets if this file is being picked up by another
+# project which has already built this as a subproject
+#-----------------------------------------------------------------------------
+if(NOT TARGET ${PN}::gg)
+    include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
+
+#    include(CMakeFindDependencyMacro)
+#    if(NOT TARGET tgt::lapack)
+#        find_dependency(TargetLAPACK)
+#    endif()
+
+    get_property(_loc TARGET ${PN}::gg PROPERTY LOCATION)
+    set(${PN}_LIBRARY ${_loc})
+    get_property(_ill TARGET ${PN}::gg PROPERTY INTERFACE_LINK_LIBRARIES)
+    set(${PN}_LIBRARIES ${_ill})
+
+    get_property(_id TARGET ${PN}::gg PROPERTY INCLUDE_DIRECTORIES)
+    set(${PN}_INCLUDE_DIR ${_id})
+    get_property(_iid TARGET ${PN}::gg PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+    set(${PN}_INCLUDE_DIRS ${_iid})
+endif()
+


### PR DESCRIPTION
* renamed the c-lib target to `gau2grid::gg` so the pb11 can by `gau2grid::pygg`
* got error below when building the pb11. `mutable_unchecked` is in current pb11 but not the 2.0 with psi4. disabled for now.

```
[ 86%] Building CXX object CMakeFiles/pygg_core.dir/pygg_core.cc.o
/home/psilocaluser/gits/gau2grid/objdir/pygg_core.cc: In function ‘void gau2grid::collocation_wrapper(int, pybind11::array_t<double>, pybind11::array_t<double>, pybind11::array_t<double>, pybind11::array_t<double>, bool, pybind11::array_t<double>)’:
/home/psilocaluser/gits/gau2grid/objdir/pygg_core.cc:18:24: error: ‘class pybind11::array_t<double>’ has no member named ‘unchecked’
     auto xyz = arr_xyz.unchecked<2>();
                        ^
/home/psilocaluser/gits/gau2grid/objdir/pygg_core.cc:18:37: error: expected primary-expression before ‘)’ token
     auto xyz = arr_xyz.unchecked<2>();
```