### PR TITLE
CMAKE: enable fpic for static lib, enable generic build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 option_with_default(ENABLE_GENERIC "Enables mostly static linking of system libraries for shared library" OFF)
 option_with_default(gau2grid_CXX_STANDARD "Specify C++ standard for core gau2grid" 11)
 option_with_default(ENABLE_PYTHON_BINDINGS "Enables pybind11 interface to C++ library" OFF)
-option_with_default(MAX_AM_ERI "The maximum gaussian angular momentum to compile" 8)
+option_with_default(MAX_AM "The maximum gaussian angular momentum to compile" 8)
 
 ########################  Process & Validate Options  ##########################
 include(autocmake_safeguards)
@@ -56,7 +56,7 @@ add_custom_command(
     COMMAND ${PYTHON_EXECUTABLE} -c "import sys; \
                                      sys.path.append('${CMAKE_SOURCE_DIR}'); \
                                      import gau2grid as gg; \
-                                     gg.c_gen.generate_c_gau2grid(${MAX_AM_ERI}, path='${CMAKE_CURRENT_BINARY_DIR}')"
+                                     gg.c_gen.generate_c_gau2grid(${MAX_AM}, path='${CMAKE_CURRENT_BINARY_DIR}')"
     DEPENDS gau2grid/c_generator.py
     VERBATIM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,17 @@ include(psi4OptionsTools)
 option_with_flags(ENABLE_XHOST "Enables processor-specific optimization" ON
                   "-xHost" "-march=native")
 option_with_default(CMAKE_BUILD_TYPE "Build type (Release or Debug)" Release)
+option_with_print(BUILD_SHARED_LIBS "Build final library as shared, not static" OFF)
+option_with_default(BUILD_FPIC "Libraries will be compiled with position independent code" ON)
+if((${BUILD_SHARED_LIBS}) AND NOT ${BUILD_FPIC})
+    message(FATAL_ERROR "BUILD_SHARED_LIBS ON and BUILD_FPIC OFF are incompatible, as shared library requires position independent code")
+endif()
 #option_with_default(CMAKE_INSTALL_LIBDIR "Directory to which libraries installed" lib)
 #option_with_default(PYMOD_INSTALL_LIBDIR "Location within CMAKE_INSTALL_LIBDIR to which python modules are installed" /)
-#option_with_default(ENABLE_GENERIC "Enables mostly static linking of system libraries for shared library" OFF)
+option_with_default(ENABLE_GENERIC "Enables mostly static linking of system libraries for shared library" OFF)
 option_with_default(gau2grid_CXX_STANDARD "Specify C++ standard for core gau2grid" 11)
 option_with_default(ENABLE_PYTHON_BINDINGS "Enables pybind11 interface to C++ library" OFF)
-option_with_default(MAX_AM "The maximum gaussian angular momentum to compile." 8)
+option_with_default(MAX_AM_ERI "The maximum gaussian angular momentum to compile" 8)
 
 ########################  Process & Validate Options  ##########################
 include(autocmake_safeguards)
@@ -41,10 +46,8 @@ find_package(pybind11 2.0.0 CONFIG REQUIRED)
 message(STATUS "${Cyan}Using pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (version ${pybind11_VERSION} for Py${PYTHON_VERSION_STRING} and ${PYBIND11_CPP_STANDARD})")
 message(STATUS "${Cyan}Using Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}${ColourReset}: ${PYTHON_EXECUTABLE}")
 
-## external projects manage their own OpenMP and c++YY flags, so only add to CXX_FLAGS for psi4-core
-#include(autocmake_omp)
 #include(custom_cxxstandard)
-#include(custom_static_library)
+include(custom_static_library)
 
 ################################  Main Project  ################################
 
@@ -53,7 +56,7 @@ add_custom_command(
     COMMAND ${PYTHON_EXECUTABLE} -c "import sys; \
                                      sys.path.append('${CMAKE_SOURCE_DIR}'); \
                                      import gau2grid as gg; \
-                                     gg.c_gen.generate_c_gau2grid(${MAX_AM}, path='${CMAKE_CURRENT_BINARY_DIR}')"
+                                     gg.c_gen.generate_c_gau2grid(${MAX_AM_ERI}, path='${CMAKE_CURRENT_BINARY_DIR}')"
     DEPENDS gau2grid/c_generator.py
     VERBATIM)
 
@@ -64,6 +67,11 @@ set(sources_list ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_phi.cc
                  ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_helper.cc)
 
 add_library(gg ${sources_list})
+set_target_properties(gg PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC})
+
+if(${BUILD_SHARED_LIBS})
+    target_link_libraries(gg PRIVATE ${LIBC_INTERJECT})
+endif()
 
 if(${ENABLE_PYTHON_BINDINGS})
     #list(APPEND sources_list ${CMAKE_CURRENT_BINARY_DIR}/pygg_core.cc)
@@ -86,7 +94,6 @@ install(TARGETS gg
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-#target_compile_definitions(efp INTERFACE USING_${PN})
 target_include_directories(gg INTERFACE
                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
@@ -100,7 +107,6 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.
                                  COMPATIBILITY AnyNewerVersion)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
-#              cmake/FindTargetLAPACK.cmake
         DESTINATION ${CMAKECONFIG_INSTALL_DIR})
 install(EXPORT "${PN}Targets"
         NAMESPACE "${PN}::"

--- a/cmake/custom_static_library.cmake
+++ b/cmake/custom_static_library.cmake
@@ -1,0 +1,56 @@
+# Downloaded from
+#   https://github.com/PCMSolver/pcmsolver/blob/release/1.Y/cmake/custom/static_library.cmake
+# * suppressed STATIC_LIBRARY_ONLY
+# * moved option up
+# * corrected CXX block matches statements from C --> CXX compiler
+
+#.rst:
+#
+# Enables creation of static library.
+# If the shared library is created, make it as static as possible.
+#
+# Variables modified (provided the corresponding language is enabled)::
+#
+#   CMAKE_Fortran_FLAGS
+#   CMAKE_C_FLAGS
+#   CMAKE_CXX_FLAGS
+#
+# autocmake.cfg configuration::
+#
+#   docopt: --static Create only the static library [default: False].
+#   define: '-DSTATIC_LIBRARY_ONLY=%s' % arguments['--static']
+
+if(ENABLE_GENERIC)
+    if(DEFINED CMAKE_Fortran_COMPILER_ID)
+        if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -static-libgfortran")
+        endif()
+        if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -static-libgcc -static-intel")
+        endif()
+    endif()
+
+    if(DEFINED CMAKE_C_COMPILER_ID)
+        if(CMAKE_C_COMPILER_ID MATCHES GNU)
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc -fpic")
+        endif()
+        if(CMAKE_C_COMPILER_ID MATCHES Intel)
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc -static-intel -wd10237")
+        endif()
+        if(CMAKE_C_COMPILER_ID MATCHES Clang)
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic")
+        endif()
+    endif()
+
+    if(DEFINED CMAKE_CXX_COMPILER_ID)
+        if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc")
+        endif()
+        if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--as-needed -static-libstdc++ -static-libgcc -static-intel -wd10237")
+        endif()
+        if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
+        endif()
+    endif()
+endif()

--- a/cmake/gau2gridConfig.cmake.in
+++ b/cmake/gau2gridConfig.cmake.in
@@ -8,7 +8,6 @@
 #   gau2grid_VERSION - gau2grid version in format Major.Minor.Release
 #   gau2grid_INCLUDE_DIRS - Directory where gau2grid header is located.
 #   gau2grid_INCLUDE_DIR - same as DIRS
-##   gau2grid_DEFINITIONS - Definitions necessary to use gau2grid, namely USING_gau2grid.
 #   gau2grid_LIBRARIES - gau2grid library to link against.
 #   gau2grid_LIBRARY - same as LIBRARIES
 #
@@ -25,13 +24,13 @@
 # target. Target is shared _or_ static, so, for both, use separate, not
 # overlapping, installations. ::
 #
-#   gau2grid::gg - the main gau2grid library with header & defs attached.
+#   gau2grid::gg - the main gau2grid library with header attached.
 #
 #
 # Suggested usage::
 #
 #   find_package(gau2grid)
-##   find_package(libefp 1.5.0 EXACT CONFIG REQUIRED COMPONENTS shared)
+##   find_package(libefp 0.1 EXACT CONFIG REQUIRED COMPONENTS shared)
 #
 #
 # The following variables can be set to guide the search for this package::
@@ -55,13 +54,8 @@ set (_valid_components
 #else()
 #    set(${PN}_static_FOUND 1)
 #endif()
-#
-#set(${PN}_DEFINITIONS USING_${PN})
 
 check_required_components(${PN})
-
-## make detectable the FindTarget*.cmake modules
-#list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
 #-----------------------------------------------------------------------------
 # Don't include targets if this file is being picked up by another
@@ -69,11 +63,6 @@ check_required_components(${PN})
 #-----------------------------------------------------------------------------
 if(NOT TARGET ${PN}::gg)
     include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
-
-#    include(CMakeFindDependencyMacro)
-#    if(NOT TARGET tgt::lapack)
-#        find_dependency(TargetLAPACK)
-#    endif()
 
     get_property(_loc TARGET ${PN}::gg PROPERTY LOCATION)
     set(${PN}_LIBRARY ${_loc})


### PR DESCRIPTION
-[x] ~`MAX_AM` --> `MAX_AM_ERI` just so ppl don't have to remember a difference~
-[x] `-DBUILD_FPIC` now does something (build `libgg.a` with `-fpic`)
-[x] add some flags so one can easily do an independent build. `-DBUILD_SHARED_LIBS=ON -DENABLE_GENERIC=ON -DLIBC_INTERJECT=/home/psilocaluser/installs/glibc2.12/lib64/libc.so.6` with Intel comps yields:

```
ldd -v libgg.so 
	linux-vdso.so.1 =>  (0x00007ffd27e13000)
	libc.so.6 => /home/psilocaluser/installs/glibc2.12/lib64/libc.so.6 (0x00007fcce52a7000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fcce588f000)
	libdl.so.2 => /home/psilocaluser/installs/glibc2.12/lib64/libdl.so.2 (0x00007fcce50a3000)

	Version information:
	./libgg.so:
		ld-linux-x86-64.so.2 (GLIBC_2.3) => /lib64/ld-linux-x86-64.so.2
		libc.so.6 (GLIBC_2.4) => /home/psilocaluser/installs/glibc2.12/lib64/libc.so.6
		libc.so.6 (GLIBC_2.2.5) => /home/psilocaluser/installs/glibc2.12/lib64/libc.so.6
	/home/psilocaluser/installs/glibc2.12/lib64/libc.so.6:
		ld-linux-x86-64.so.2 (GLIBC_PRIVATE) => /lib64/ld-linux-x86-64.so.2
		ld-linux-x86-64.so.2 (GLIBC_2.3) => /lib64/ld-linux-x86-64.so.2
	/home/psilocaluser/installs/glibc2.12/lib64/libdl.so.2:
		ld-linux-x86-64.so.2 (GLIBC_PRIVATE) => /lib64/ld-linux-x86-64.so.2
		libc.so.6 (GLIBC_PRIVATE) => /home/psilocaluser/installs/glibc2.12/lib64/libc.so.6
		libc.so.6 (GLIBC_2.2.5) => /home/psilocaluser/installs/glibc2.12/lib64/libc.so.6
```