### PR TITLE
install as python module from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,12 @@ option_with_default(ENABLE_GENERIC "Enables mostly static linking of system libr
 if((${BUILD_SHARED_LIBS}) AND NOT ${BUILD_FPIC})
     message(FATAL_ERROR "BUILD_SHARED_LIBS ON and BUILD_FPIC OFF are incompatible, as shared library requires position independent code")
 endif()
-#option_with_default(CMAKE_INSTALL_LIBDIR "Directory to which libraries installed" lib)
-#option_with_default(PYMOD_INSTALL_LIBDIR "Location within CMAKE_INSTALL_LIBDIR to which python modules are installed" /)
+
+# Install
+option_with_default(CMAKE_INSTALL_LIBDIR "Directory to which libraries installed" lib)
+option_with_default(PYMOD_INSTALL_LIBDIR "Location within CMAKE_INSTALL_LIBDIR to which python modules are installed
+                                          Must start with: / . Used to imitate python install: /python3.6/site-packages ." /)
+option_with_print(INSTALL_PYMOD "Additionally installs as independent python module in PYMOD_INSTALL_LIBDIR" OFF)
 
 ########################  Process & Validate Options  ##########################
 include(autocmake_safeguards)
@@ -104,3 +108,12 @@ install(EXPORT "${PN}Targets"
         NAMESPACE "${PN}::"
         DESTINATION ${CMAKECONFIG_INSTALL_DIR})
 
+if(${INSTALL_PYMOD})
+    install(DIRECTORY gau2grid
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}
+            USE_SOURCE_PERMISSIONS
+            FILES_MATCHING PATTERN "*.py")
+
+    install(FILES $<TARGET_FILE:gg>
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/gau2grid)
+endif()


### PR DESCRIPTION
This is a cheat to install g2g as a python module w/o involving setup.py (and thus ensuring that not rebuilding libgg with a different set of options). If `-DINSTALL_PYMOD` passed to CM, will form a python module dir with a copy of main library in CMAKE_INSTALL_LIBDIR/PYMOD_INSTALL_LIBDIR, after which `PYTHONPATH=../install2/lib/python3.6/site-packages/ python -c "import gau2grid as gg; gg.test(); print(gg.__version__)"` works.

- [ ] Whether you want `CMAKE_INSTALL_LIBDIR` in main CMlists is entirely up to you. Its default (according to GNU) is `lib64`, so I usually add it with a plain `lib` default. You probably won't have noticed this in the psi context b/c I'm always overwriting it to `lib`, but it does show up in a standalone build. The `PYMOD_INSTALL_LIBDIR` is needed b/c it has no default.

- [ ] I'm planning to use this mostly for testing, so the `site-packages/gau2grid` won't show up in psi4 builds or conda pkg `gau2grid`. But I can publish a separate conda pkg of `pygau2grid` if you like. In that case, the fact that it needs `import mpmath` starts to become an annoyance b/c it's not actually true. Would you want a separate `__init__.py` for the runtime mode?

Also note that this isn't the more sophisticated CMake treatment of a py module where `<pkg>Config.cmake` actually knows where the module is (as v2rdm does). The CMake package handling is still purely focused on the Linux lib `lib/libgg.so`. But, as you say, python linking can take care of itself at RT.