### PR TITLE
Porting to Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+image: Visual Studio 2017
+clone_depth: 5
+
+install:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - C:\Miniconda36-x64\Scripts\activate base
+  - conda install --yes numpy mpmath pytest
+  - conda list
+
+before_build:
+  - mkdir build & cd build
+  - cmake -A x64
+          -DCMAKE_C_FLAGS="/wd4018 /wd4101 /wd4996"
+          -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=true
+          -DINSTALL_PYMOD=ON
+          ..
+
+build_script:
+  - cmake --build .
+
+after_build:
+  # TODO: fix installation
+  - cmake --build . --target install
+
+before_test:
+  - cd ..
+  # Copy the library manualy as the installation is broken
+  - copy build\Debug\gg.dll gau2grid\libgg.dll
+
+test_script:
+  - pytest

--- a/gau2grid/RSH.py
+++ b/gau2grid/RSH.py
@@ -3,6 +3,7 @@ Cartesian to regular solid harmonics conversion code.
 """
 
 import os
+import platform
 import numpy as np
 
 from . import order
@@ -37,7 +38,9 @@ def _load_saved_rsh_coefs():
         _saved_rsh_coefs[AM] = am_data
 
 
-_load_saved_rsh_coefs()
+# Windows does not support caching due to missing numpy.float128
+if platform.system() != 'Windows':
+    _load_saved_rsh_coefs()
 
 class RSH_Memoize(object):
     """
@@ -160,6 +163,10 @@ def cart_to_RSH_coeffs(L, order="gaussian", gen=False, force_call=True):
         "CCA":
             R^-_(l), R^-_(l-1), ..., R_0, ..., R^+_(l-1), R^+_l
     """
+
+    # Windows does not support caching due to missing numpy.float128
+    gen = True if platform.system() == 'Windows' else gen
+
     if gen:
         data = _cart_to_RSH_coeffs_gen(L, force_call=force_call)
     else:

--- a/gau2grid/c_generator.py
+++ b/gau2grid/c_generator.py
@@ -73,7 +73,11 @@ def generate_c_gau2grid(max_L, path=".", cartesian_order="row", spherical_order=
     for cgs in [gg_phi, gg_grad, gg_hess, gg_spherical, gg_helper]:
         cgs.write("#include <math.h>")
         cgs.write("#include <stdio.h>")
+        cgs.write("#ifdef _MSC_VER")
+        cgs.write("#include <malloc.h>")
+        cgs.write("#else")
         cgs.write("#include <mm_malloc.h>")
+        cgs.write("#endif")
         cgs.blankline()
         cgs.write('#include "gau2grid.h"')
         cgs.write('#include "gau2grid_pragma.h"')
@@ -86,6 +90,11 @@ def generate_c_gau2grid(max_L, path=".", cartesian_order="row", spherical_order=
     gg_header.blankline()
     gg_header.write("#ifndef GAU2GRID_GUARD_H")
     gg_header.write("#define GAU2GRID_GUARD_H")
+    gg_header.blankline()
+
+    gg_header.write("#ifdef _MSC_VER")
+    gg_header.write("#define __restrict__ __restrict")
+    gg_header.write("#endif")
     gg_header.blankline()
 
     # Add any information needed

--- a/gau2grid/c_pragma.py
+++ b/gau2grid/c_pragma.py
@@ -18,6 +18,10 @@ _pragma_data = """
     // pragmas for GCC
     #define PRAGMA_VECTORIZE                                _Pragma("GCC ivdep")
 
+#elif defined(_MSC_VER)
+    // pragmas for MSVC
+    #define PRAGMA_VECTORIZE                                 __pragma(loop(ivdep))
+
 #endif
 """
 

--- a/gau2grid/c_util_generator.py
+++ b/gau2grid/c_util_generator.py
@@ -226,7 +226,11 @@ def fast_transpose(cg, inner_block):
     cg.blankline()
 
     cg.write("// Temps")
-    cg.write("double tmp[%d]  __attribute__((aligned(64)))" % (inner_block * inner_block))
+    cg.write("#ifdef _MSC_VER")
+    cg.write("__declspec(align(64)) double tmp[%d]" % (inner_block * inner_block))
+    cg.write("#else")
+    cg.write("double tmp[%d] __attribute__((aligned(64)))" % (inner_block * inner_block))
+    cg.write("#endif")
 
     cg.write("// Sizing")
     cg.write("unsigned long nblocks = n / %d" % inner_block)

--- a/gau2grid/tests/test_c_generator.py
+++ b/gau2grid/tests/test_c_generator.py
@@ -4,6 +4,7 @@ Compare the generated C code against the NumPy reference code.
 
 import numpy as np
 import pytest
+from tempfile import TemporaryDirectory
 
 import gau2grid as gg
 
@@ -31,7 +32,8 @@ def test_c_spherical_trans_codgen(AM):
 
 
 def test_library_gen():
-    gg.c_gen.generate_c_gau2grid(4, path="/tmp")
+    with TemporaryDirectory() as temp_dir:
+        gg.c_gen.generate_c_gau2grid(4, path=temp_dir)
 
 
 def test_pybind11_gen():

--- a/gau2grid/tests/test_rsh.py
+++ b/gau2grid/tests/test_rsh.py
@@ -3,6 +3,7 @@ Compare the generated NumPy code against the NumPy reference code.
 """
 
 import pytest
+import platform
 import numpy as np
 np.set_printoptions(precision=30)
 
@@ -30,11 +31,16 @@ def _test_shell(bench, comp):
 
         # Check coefficient
         # print(type(comp_coeff[1]), np.array([comp_coeff[1]]), np.float128(bench_coeff[1]), bench_coeff[1])
-        assert pytest.approx(comp_coeff[1], rel=1.e-16) == np.float128(bench_coeff[1])
+        # numpy.float128 is missing on Windows
+        if platform.system() == "Windows":
+            assert pytest.approx(comp_coeff[1], rel=1.e-16) == np.float64(bench_coeff[1])
+        else:
+            assert pytest.approx(comp_coeff[1], rel=1.e-16) == np.float128(bench_coeff[1])
 
     return True
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Windows does not support caching due to missing numpy.float128")
 @pytest.mark.skipif(_has_mpmath is False, reason="Did not detect mpmath module")
 #@pytest.mark.parametrize("AM", range(6))
 @pytest.mark.parametrize("AM", range(17))
@@ -50,6 +56,7 @@ def test_RSH(AM):
         assert _test_shell(bench_data[sph], pkl_data[sph])
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Windows does not support caching due to missing numpy.float128")
 def test_RSH_max_am():
     with pytest.raises(ValueError):
         pkl_data = gg.RSH.cart_to_RSH_coeffs(17, gen=False)


### PR DESCRIPTION
This is part of *Psi4* porting to Windows (https://github.com/psi4/psi4/issues/933):

- [x] Add MSVC support to the code generators
- [x] Disable RSH coefficient caching on Windows (do not work due to missing `numpy.float128`)
- [x] Appveyor configuration to compile and tests on Windows (https://ci.appveyor.com/project/raimis/gau2grid). Appveyor has to be activated on the repository to work (https://www.appveyor.com/docs/).

I haven't yet fixed installation on Windows.