### PR TITLE
Moves from `_mm_malloc` to `aligned_alloc` where possible.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,9 +78,9 @@ set(sources_list ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_phi.c
 
 add_library(gg ${sources_list})
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "PGI")
-    set_target_properties(gg PROPERTIES COMPILE_FLAGS "-c99")
+    set_target_properties(gg PROPERTIES COMPILE_FLAGS "-c11")
 else()
-    set_target_properties(gg PROPERTIES COMPILE_FLAGS "-std=c99")
+    set_target_properties(gg PROPERTIES COMPILE_FLAGS "-std=c11")
 endif()
 set_target_properties(gg PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
                                     SOVERSION 1)  # bump whenever interface has changes or removals

--- a/gau2grid/c_generator.py
+++ b/gau2grid/c_generator.py
@@ -81,10 +81,12 @@ def generate_c_gau2grid(max_L,
     for cgs in [gg_orbital, gg_phi, gg_grad, gg_hess, gg_spherical, gg_helper]:
         cgs.write("#include <math.h>")
         cgs.write("#include <stdio.h>")
-        cgs.write("#ifdef _MSC_VER")
+        cgs.write("#if defined __clang__")
+        cgs.write("#include <mm_malloc.h>")
+        cgs.write("#elif defined _MSC_VER")
         cgs.write("#include <malloc.h>")
         cgs.write("#else")
-        cgs.write("#include <mm_malloc.h>")
+        cgs.write("#include <stdlib.h>")
         cgs.write("#endif")
         cgs.blankline()
         cgs.write('#include "gau2grid.h"')
@@ -619,7 +621,7 @@ def shell_c_generator(cg, L, function_name="", grad=0, cartesian_order="row", in
 
         cg.write("// Free %s temporaries" % name)
         for tname in flist:
-            cg.write("_mm_free(%s)" % tname)
+            cg.write("ALIGNED_FREE(%s)" % tname)
         cg.blankline()
 
     # End function
@@ -685,7 +687,7 @@ def _make_call(string):
 
 def _malloc(name, size, dtype="double"):
     # return "%s*  %s = (%s*)malloc(%s * sizeof(%s))" % (dtype, name, dtype, str(size), dtype)
-    return "%s* PRAGMA_RESTRICT %s = (%s*)_mm_malloc(%s * sizeof(%s), %d)" % (dtype, name, dtype, str(size), dtype, ALIGN_SIZE)
+    return "%s* PRAGMA_RESTRICT %s = (%s*)ALIGNED_MALLOC(%d, %s * sizeof(%s))" % (dtype, name, dtype, ALIGN_SIZE, str(size), dtype)
 
 
 def _block_malloc(cg, block_name, mallocs, dtype="double"):

--- a/gau2grid/c_pragma.py
+++ b/gau2grid/c_pragma.py
@@ -7,35 +7,55 @@ _pragma_data = """
 
 #if defined(__ICC) || defined(__INTEL_COMPILER)
     // pragmas for Intel
+
+    #define ALIGNED_MALLOC(alignment, size)                  aligned_alloc(size, alignment)
+    #define ALIGNED_FREE(ptr)                                free(ptr)
+    #define ASSUME_ALIGNED(ptr, width)                       __assume_aligned(ptr, width)
+
     #define PRAGMA_VECTORIZE                                 _Pragma("vector")
     #define PRAGMA_RESTRICT                                  __restrict__
-    #define ASSUME_ALIGNED(ptr, width)                       __assume_aligned(ptr, width)
 
 #elif defined(__clang__)
     // pragmas for Clang.
     // Do this before GCC because clang also defines __GNUC__
+
+    #define ALIGNED_MALLOC(alignment, size)                  _mm_malloc(size, alignment)
+    #define ALIGNED_FREE(ptr)                                _mm_free(ptr)
+    #define ASSUME_ALIGNED(ptr, width)
+
     #define PRAGMA_VECTORIZE                                 _Pragma("clang loop vectorize(enable)")
     #define PRAGMA_RESTRICT                                  __restrict__
-    #define ASSUME_ALIGNED(ptr, width)
 
 #elif defined(__GNUC__) || defined(__GNUG__)
     // pragmas for GCC
+
+    #define ALIGNED_MALLOC(alignment, size)                  aligned_alloc(alignment, size)
+    #define ALIGNED_FREE(ptr)                                free(ptr)
+    #define ASSUME_ALIGNED(ptr, width)
+
     #define PRAGMA_VECTORIZE                                 _Pragma("GCC ivdep")
     #define PRAGMA_RESTRICT                                  __restrict__
-    #define ASSUME_ALIGNED(ptr, width)
 
 #elif defined(_MSC_VER)
     // pragmas for MSVC
+
+    #define ALIGNED_MALLOC(alignment, size)                  _aligned_malloc(size, alignment)
+    #define ALIGNED_FREE(ptr)                                _aligned_free(ptr)
+    #define ASSUME_ALIGNED(ptr, width)
+
     #define PRAGMA_VECTORIZE                                 __pragma(loop(ivdep))
     #define PRAGMA_RESTRICT                                  __restrict
-    #define ASSUME_ALIGNED(ptr, width)
 
 
 #elif defined(__PGI)
     // pragmas for PGI
+
+    #define ALIGNED_MALLOC(alignment, size)                  aligned_alloc(alignment, size)
+    #define ALIGNED_FREE(ptr)                                free(ptr)
+    #define ASSUME_ALIGNED(ptr, width)
+
     #define PRAGMA_VECTORIZE                                 _Pragma("ivdep")
     #define PRAGMA_RESTRICT                                  __restrict__
-    #define ASSUME_ALIGNED(ptr, width)
 
 
 #endif

--- a/gau2grid/c_wrapper.py
+++ b/gau2grid/c_wrapper.py
@@ -218,7 +218,7 @@ def collocation(xyz,
     _validate_c_import()
 
     if L > cgg.gg_max_L():
-        raise ValueError("LibGG was only compiled to AM=%d, requested AM=%d." % (cgg.max_L(), L))
+        raise ValueError("LibGG was only compiled to AM=%d, requested AM=%d." % (cgg.gg_max_L(), L))
 
     # Check XYZ
     if xyz.shape[0] != 3:


### PR DESCRIPTION
Appears Mac clang does not have full c11 support (no `aligned_alloc`). Also, MSVC requires a special `_aligned_malloc`. Should address #25.