### PR TITLE
cmake: add very basic soversion to library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,13 +77,13 @@ set(sources_list ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_phi.c
                  ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_helper.c)
 
 add_library(gg ${sources_list})
-#set_target_properties(gg PROPERTIES COMPILE_FLAGS "-std=c99")
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "PGI")
-   set_target_properties(gg PROPERTIES COMPILE_FLAGS "-c99")
- else()
-   set_target_properties(gg PROPERTIES COMPILE_FLAGS "-std=c99")
- endif()
-set_target_properties(gg PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC})
+    set_target_properties(gg PROPERTIES COMPILE_FLAGS "-c99")
+else()
+    set_target_properties(gg PROPERTIES COMPILE_FLAGS "-std=c99")
+endif()
+set_target_properties(gg PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
+                                    SOVERSION 1)  # bump whenever interface has changes or removals
 
 if(${BUILD_SHARED_LIBS})
     target_link_libraries(gg PRIVATE ${LIBC_INTERJECT})


### PR DESCRIPTION
Beyond whitespace this is a one-line change.

Differs from #23 in that SONAME not tied to project versioning. Proper procedure is to run an abi-diff-ing tool at every new tag and increment the SOVERSION if _not_ backwards compatible. The more common procedure, I suspect, is to just guess and increment if interfaces have changed or been removed.