### PR TITLE
python looks for .so, not .so.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,12 @@ install(EXPORT "${PN}Targets"
         DESTINATION ${CMAKECONFIG_INSTALL_DIR})
 
 if(${INSTALL_PYMOD})
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+                    "from numpy import distutils; print(distutils.misc_util.get_shared_lib_extension(is_python_ext=False))"
+                    OUTPUT_VARIABLE PYLIB_EXTENSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message("QWER ${PYLIB_EXTENSION}")
+
     install(DIRECTORY gau2grid
             DESTINATION ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}
             USE_SOURCE_PERMISSIONS
@@ -144,5 +150,5 @@ if(${INSTALL_PYMOD})
 
     install(FILES $<TARGET_FILE:gg>
             DESTINATION ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/gau2grid
-            RENAME libgg.so)
+            RENAME "libgg${PYLIB_EXTENSION}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 project(gau2grid
-        VERSION 1.2.0
+        VERSION 1.3.0
         LANGUAGES C)
 set(gau2grid_AUTHORS      "Daniel G. A. Smith")
 set(gau2grid_DESCRIPTION  "Fast computation of a gaussian and its derivative on a grid")
@@ -67,6 +67,17 @@ add_custom_command(
                                      import gau2grid as gg; \
                                      gg.c_gen.generate_c_gau2grid(${MAX_AM}, path='${CMAKE_CURRENT_BINARY_DIR}', cartesian_order='${CARTESIAN_ORDER}', spherical_order='${SPHERICAL_ORDER}')"
     DEPENDS gau2grid/c_generator.py
+            gau2grid/c_generator.py
+            gau2grid/codegen.py
+            gau2grid/c_pragma.py
+            gau2grid/c_util_generator.py
+            gau2grid/c_wrapper.py
+            gau2grid/docs_generator.py
+            gau2grid/np_generator.py
+            gau2grid/order.py
+            gau2grid/python_reference.py
+            gau2grid/RSH.py
+            gau2grid/utility.py
     VERBATIM)
 
 set(sources_list ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_phi.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,5 +132,6 @@ if(${INSTALL_PYMOD})
             FILES_MATCHING PATTERN "*.py")
 
     install(FILES $<TARGET_FILE:gg>
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/gau2grid)
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/gau2grid
+            RENAME libgg.so)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,5 +150,6 @@ if(${INSTALL_PYMOD})
 
     install(FILES $<TARGET_FILE:gg>
             DESTINATION ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}/gau2grid
-            RENAME "libgg${PYLIB_EXTENSION}")
+            RENAME "gg${PYLIB_EXTENSION}")
+            #RENAME "libgg${PYLIB_EXTENSION}")
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,18 @@ install:
   - conda list
 
 before_build:
-  - mkdir build & cd build
+  - set SOURCE_FOLDER=%APPVEYOR_BUILD_FOLDER%
+  - set BUILD_FOLDER=%SOURCE_FOLDER%\build
+  - set INSTALL_FOLDER=%SOURCE_FOLDER%\install
+  - mkdir %BUILD_FOLDER% & cd %BUILD_FOLDER%
+#  - cmake -G Ninja
+#          -DCMAKE_BUILD_TYPE=%CONFIGURATION%
+#          -DCMAKE_INSTALL_PREFIX=%INSTALL_FOLDER%
+#  - mkdir build & cd build
   - cmake -A x64
           -DCMAKE_C_FLAGS="/wd4018 /wd4101 /wd4996"
           -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=true
+          -DCMAKE_INSTALL_PREFIX=%INSTALL_FOLDER%
           -DINSTALL_PYMOD=ON
           ..
 
@@ -24,8 +32,9 @@ after_build:
 
 before_test:
   - cd ..
+  - set PYTHONPATH=%INSTALL_FOLDER%\lib
   # Copy the library manualy as the installation is broken
   #- copy build\Debug\gg.dll gau2grid\libgg.dll
 
 test_script:
-  - PYTHONPATH=/usr/local/gau2grid/lib/ pytest -rws -v /usr/local/gau2grid/
+  - pytest -rws -v %INSTALL_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_depth: 5
 install:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - C:\Miniconda36-x64\Scripts\activate base
-  - conda install --yes numpy mpmath pytest
+  - conda install --yes numpy pytest
   - conda list
 
 before_build:
@@ -25,7 +25,7 @@ after_build:
 before_test:
   - cd ..
   # Copy the library manualy as the installation is broken
-  - copy build\Debug\gg.dll gau2grid\libgg.dll
+  #- copy build\Debug\gg.dll gau2grid\libgg.dll
 
 test_script:
   - pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,4 +28,4 @@ before_test:
   #- copy build\Debug\gg.dll gau2grid\libgg.dll
 
 test_script:
-  - pytest
+  - PYTHONPATH=/usr/local/gau2grid/lib/ pytest -rws -v /usr/local/gau2grid/

--- a/gau2grid/c_pragma.py
+++ b/gau2grid/c_pragma.py
@@ -8,8 +8,8 @@ _pragma_data = """
 #if defined(__ICC) || defined(__INTEL_COMPILER)
     // pragmas for Intel
 
-    #define ALIGNED_MALLOC(alignment, size)                  aligned_alloc(size, alignment)
-    #define ALIGNED_FREE(ptr)                                free(ptr)
+    #define ALIGNED_MALLOC(alignment, size)                  _mm_malloc(size, alignment)
+    #define ALIGNED_FREE(ptr)                                _mm_free(ptr)
     #define ASSUME_ALIGNED(ptr, width)                       __assume_aligned(ptr, width)
 
     #define PRAGMA_VECTORIZE                                 _Pragma("vector")

--- a/gau2grid/c_wrapper.py
+++ b/gau2grid/c_wrapper.py
@@ -19,7 +19,7 @@ cgg = None
 # First check the local folder
 try:
     abs_path = os.path.dirname(os.path.abspath(__file__))
-    cgg = np.ctypeslib.load_library("libgg", abs_path)
+    cgg = np.ctypeslib.load_library("gg", abs_path)
     __libgg_path = os.path.join(abs_path, cgg._name)
     __lib_found = True
 except OSError:

--- a/gau2grid/tests/test_c_code.py
+++ b/gau2grid/tests/test_c_code.py
@@ -139,7 +139,7 @@ def test_generator_derivs_spherical(grad):
 
 @check_compile
 def test_libgg_path():
-    assert "libgg" in gg.cgg_path()
+    assert "gg" in gg.cgg_path()
 
 
 @check_compile


### PR DESCRIPTION
- [x] thank goodness py on mac looks for `.so`, not `.dylib`. Win is probably still in trouble. using `.so` in py instead of `so.1`
- [x] at @dgasmith suggestion, fix intel compilers (broken since #27) by adjusting pragmas
- [x] make sure c code regenerates with changes to py generating code