### PR TITLE
Allows transposed XYZ input

### DIFF
--- a/docs/source/c_api.rst
+++ b/docs/source/c_api.rst
@@ -54,7 +54,7 @@ Orbital Functions
 Computes orbitals on a grid.
 
 
-.. c:function:: void gg_orbitals(int L, const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT x, const double* PRAGMA_RESTRICT y, const double* PRAGMA_RESTRICT z, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out)
+.. c:function:: void gg_orbitals(int L, const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out)
 
     Computes orbital a section on a grid. This function performs the following
     contraction inplace.
@@ -70,9 +70,8 @@ Computes orbitals on a grid.
     :param C: A ``(norbitals, ncomponents)`` matrix of orbital coefficients.
     :param norbitals: The number of orbs to compute.
     :param npoints: The number of grid points to compute.
-    :param x: A ``(npoints, )`` array of x coordinates.
-    :param y: A ``(npoints, )`` array of y coordinates.
-    :param z: A ``(npoints, )`` array of z coordinates.
+    :param xyz: A ``(npoints, 3)`` or (npoints, n) array of the xyz coordinates.
+    :param xyz_stride: The stride of the xyz input array. 1 for ``xx..., yy..., zz...`` style input, 3 for ``xyz, xyz, xyz, ...`` style input.
     :param nprim: The number of primitives (exponents and coefficients) in the basis set
     :param coeffs: A ``(nprim, )`` array of coefficients (:math:`c`).
     :param exponents: A ``(nprim, )`` array of exponents (:math:`\alpha`).
@@ -86,7 +85,7 @@ Collocation Functions
 Creates collocation matrices between a gaussian function and a set of grid points.
 
 
-.. c:function:: void gg_collocation(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT x, const double* PRAGMA_RESTRICT y, const double* PRAGMA_RESTRICT z, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out)
+.. c:function:: void gg_collocation(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out)
 
     Computes the collocation array:
 
@@ -96,9 +95,8 @@ Creates collocation matrices between a gaussian function and a set of grid point
 
     :param L: The angular momentum of the basis function.
     :param npoints: The number of grid points to compute.
-    :param x: A ``(npoints, )`` array of x coordinates.
-    :param y: A ``(npoints, )`` array of y coordinates.
-    :param z: A ``(npoints, )`` array of z coordinates.
+    :param xyz: A ``(npoints, 3)`` or (npoints, n) array of the xyz coordinates.
+    :param xyz_stride: The stride of the xyz input array. 1 for ``xx..., yy..., zz...`` style input, 3 for ``xyz, xyz, xyz, ...`` style input.
     :param nprim: The number of primitives (exponents and coefficients) in the basis set
     :param coeffs: A ``(nprim, )`` array of coefficients (:math:`c`).
     :param exponents: A ``(nprim, )`` array of exponents (:math:`\alpha`).
@@ -106,7 +104,7 @@ Creates collocation matrices between a gaussian function and a set of grid point
     :param order: Enum that specifies the output order.
     :param phi_out: ``(ncomponents, npoints)`` collocation array.
 
-.. c:function:: void gg_collocation_deriv1(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT x, const double* PRAGMA_RESTRICT y, const double* PRAGMA_RESTRICT z, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out)
+.. c:function:: void gg_collocation_deriv1(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out)
 
     Computes the collocation array and the corresponding first cartesian derivatives:
 
@@ -116,9 +114,8 @@ Creates collocation matrices between a gaussian function and a set of grid point
 
     :param L: The angular momentum of the basis function.
     :param npoints: The number of grid points to compute.
-    :param x: A ``(npoints, )`` array of x coordinates.
-    :param y: A ``(npoints, )`` array of y coordinates.
-    :param z: A ``(npoints, )`` array of z coordinates.
+    :param xyz: A ``(npoints, 3)`` or (npoints, n) array of the xyz coordinates.
+    :param xyz_stride: The stride of the xyz input array. 1 for ``xx..., yy..., zz...`` style input, 3 for ``xyz, xyz, xyz, ...`` style input.
     :param nprim: The number of primitives (exponents and coefficients) in the basis set
     :param coeffs: A ``(nprim, )`` array of coefficients (:math:`c`).
     :param exponents: A ``(nprim, )`` array of exponents (:math:`\alpha`).
@@ -130,7 +127,7 @@ Creates collocation matrices between a gaussian function and a set of grid point
     :param phi_z_out: ``(ncomponents, npoints)`` collocation derivative with respect to ``z``.
 
 
-.. c:function:: void gg_collocation_deriv2(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT x, const double* PRAGMA_RESTRICT y, const double* PRAGMA_RESTRICT z, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out)
+.. c:function:: void gg_collocation_deriv2(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out)
 
     Computes the collocation array and the corresponding first and second cartesian derivatives:
 
@@ -140,9 +137,8 @@ Creates collocation matrices between a gaussian function and a set of grid point
 
     :param L: The angular momentum of the basis function.
     :param npoints: The number of grid points to compute.
-    :param x: A ``(npoints, )`` array of x coordinates.
-    :param y: A ``(npoints, )`` array of y coordinates.
-    :param z: A ``(npoints, )`` array of z coordinates.
+    :param xyz: A ``(npoints, 3)`` or (npoints, n) array of the xyz coordinates.
+    :param xyz_stride: The stride of the xyz input array. 1 for ``xx..., yy..., zz...`` style input, 3 for ``xyz, xyz, xyz, ...`` style input.
     :param nprim: The number of primitives (exponents and coefficients) in the basis set
     :param coeffs: A ``(nprim, )`` array of coefficients (:math:`c`).
     :param exponents: A ``(nprim, )`` array of exponents (:math:`\alpha`).

--- a/docs/source/c_example.rst
+++ b/docs/source/c_example.rst
@@ -16,9 +16,10 @@ starting at the origin along the ``z`` axis and a ``S`` shell at the origin:
   int main() {
       // Generate grid
       long int npoints = 5;
-      double x[5] = {0, 0, 0, 0, 0};
-      double y[5] = {0, 0, 0, 0, 0};
-      double z[5] = {0, 1, 2, 3, 4};
+      double xyz[15] = {0, 0, 0, 0, 0, // x components
+                        0, 0, 0, 0, 0}; // y components
+                        0, 1, 2, 3, 4}; // z components
+      long int xyz_shape = 1; // This is a contiguous format
 
       // Gaussian data
       int nprim = 1;
@@ -29,7 +30,7 @@ starting at the origin along the ``z`` axis and a ``S`` shell at the origin:
 
       double s_output[5] = {0};
       gg_collocation(0,                                // The angular momentum
-                     npoints, x, y, z,                 // Grid data
+                     npoints, xyz, xyz_shape,          // Grid data
                      nprim, coef, exp, center, order,  // Gaussian data
                      s_output);                        // Output
 
@@ -52,6 +53,27 @@ component starts at position ``0``, the ``Y`` component starts at position
 ``5``, and the ``Z`` component starts at position ``10`` as out grid is of
 length ``5``. See :ref:`Gaussian Component Orders <gpo_order>` for more details or order output.
 
+The xyz input shape can either be organized contigously in each dimension like
+the above or packed in a xyz, xyz, ... fashion. If the ``xyz_shape`` is not 1,
+the shape refers to the strides per row. For example, if the data is packed as
+xyzw, xyzw, ... (where w could be a DFT grid weight) the ``xyz_shape`` should
+be 4.
+
+.. code-block:: C
+
+      long int xyz_shape = 3;
+      double xyz[15] = {0, 0, 0,
+                        0, 0, 1,
+                        0, 0, 2,
+                        0, 0, 3,
+                        0, 0, 4}; // xyz, xyz, ... format
+
+
+      gg_collocation(0,                                // The angular momentum
+                     npoints, xyz, xyz_shape,          // Grid data
+                     nprim, coef, exp, center, order,  // Gaussian data
+                     s_output);                        // Output
+
 Multiple Basis Functions
 ------------------------
 
@@ -66,9 +88,10 @@ The below is an example of usage:
   int main() {
       // Generate grid
       long int npoints = 5;
-      double x[5] = {0, 0, 0, 0, 0};
-      double y[5] = {0, 0, 0, 0, 0};
-      double z[5] = {0, 1, 2, 3, 4};
+      double xyz[15] = {0, 0, 0, 0, 0, // x components
+                        0, 0, 0, 0, 0}; // y components
+                        0, 1, 2, 3, 4}; // z components
+      long int xyz_shape = 1;
 
       // Gaussian data
       int nprim = 1;
@@ -82,7 +105,7 @@ The below is an example of usage:
       int row = 0;
       for (int L = 0; L < 3; L++) {
           gg_collocation(L,                                 // The angular momentum
-                         npoints, x, y, z,                  // Grid data
+                         npoints, xyz, xyz_shape            // Grid data
                          nprim, coef, exp, center, order,   // Gaussian data
                          output + (row * npoints));         // Output, shift pointer
 

--- a/docs/source/c_example.rst
+++ b/docs/source/c_example.rst
@@ -19,7 +19,7 @@ starting at the origin along the ``z`` axis and a ``S`` shell at the origin:
       double xyz[15] = {0, 0, 0, 0, 0, // x components
                         0, 0, 0, 0, 0}; // y components
                         0, 1, 2, 3, 4}; // z components
-      long int xyz_shape = 1; // This is a contiguous format
+      long int xyz_stride = 1; // This is a contiguous format
 
       // Gaussian data
       int nprim = 1;
@@ -30,7 +30,7 @@ starting at the origin along the ``z`` axis and a ``S`` shell at the origin:
 
       double s_output[5] = {0};
       gg_collocation(0,                                // The angular momentum
-                     npoints, xyz, xyz_shape,          // Grid data
+                     npoints, xyz, xyz_stride,          // Grid data
                      nprim, coef, exp, center, order,  // Gaussian data
                      s_output);                        // Output
 
@@ -54,14 +54,14 @@ component starts at position ``0``, the ``Y`` component starts at position
 length ``5``. See :ref:`Gaussian Component Orders <gpo_order>` for more details or order output.
 
 The xyz input shape can either be organized contigously in each dimension like
-the above or packed in a xyz, xyz, ... fashion. If the ``xyz_shape`` is not 1,
+the above or packed in a xyz, xyz, ... fashion. If the ``xyz_stride`` is not 1,
 the shape refers to the strides per row. For example, if the data is packed as
-xyzw, xyzw, ... (where w could be a DFT grid weight) the ``xyz_shape`` should
+xyzw, xyzw, ... (where w could be a DFT grid weight) the ``xyz_stride`` should
 be 4.
 
 .. code-block:: C
 
-      long int xyz_shape = 3;
+      long int xyz_stride = 3;
       double xyz[15] = {0, 0, 0,
                         0, 0, 1,
                         0, 0, 2,
@@ -70,7 +70,7 @@ be 4.
 
 
       gg_collocation(0,                                // The angular momentum
-                     npoints, xyz, xyz_shape,          // Grid data
+                     npoints, xyz, xyz_stride,          // Grid data
                      nprim, coef, exp, center, order,  // Gaussian data
                      s_output);                        // Output
 
@@ -91,7 +91,7 @@ The below is an example of usage:
       double xyz[15] = {0, 0, 0, 0, 0, // x components
                         0, 0, 0, 0, 0}; // y components
                         0, 1, 2, 3, 4}; // z components
-      long int xyz_shape = 1;
+      long int xyz_stride = 1;
 
       // Gaussian data
       int nprim = 1;
@@ -105,7 +105,7 @@ The below is an example of usage:
       int row = 0;
       for (int L = 0; L < 3; L++) {
           gg_collocation(L,                                 // The angular momentum
-                         npoints, xyz, xyz_shape            // Grid data
+                         npoints, xyz, xyz_stride            // Grid data
                          nprim, coef, exp, center, order,   // Gaussian data
                          output + (row * npoints));         // Output, shift pointer
 

--- a/gau2grid/__init__.py
+++ b/gau2grid/__init__.py
@@ -9,7 +9,7 @@ from . import order
 from . import python_reference as ref
 
 # Pull in code from the c wrapper
-from .c_wrapper import (orbital, orbital_basis, collocation, collocation_basis, c_compiled, cgg_path, ncomponents)
+from .c_wrapper import (orbital, orbital_basis, collocation, collocation_basis, c_compiled, cgg_path, ncomponents, get_cgg_shared_object)
 # Pull in tests
 from .extras import test
 

--- a/gau2grid/c_generator.py
+++ b/gau2grid/c_generator.py
@@ -465,7 +465,7 @@ def shell_c_generator(cg, L, function_name="", grad=0, cartesian_order="row", in
 
     # Two different loop options
     cg.write("// Handle non-AM dependant temps")
-    cg.start_c_block("if (shift == 1)",)
+    cg.start_c_block("if (xyz_stride == 1)",)
 
     # Contigous data blocks
     cg.write("const double* PRAGMA_RESTRICT x = xyz + start")
@@ -496,14 +496,14 @@ def shell_c_generator(cg, L, function_name="", grad=0, cartesian_order="row", in
     cg.write("} else {", endl="")
 
     # XYZ stripped blocks
-    cg.write("unsigned int start_shift = start * shift")
+    cg.write("unsigned int start_shift = start * xyz_stride")
     cg.blankline()
 
     cg.write("PRAGMA_VECTORIZE", endl="")
     cg.start_c_block("for (unsigned long i = 0; i < remain; i++)")
-    cg.write("xc[i] = xyz[start_shift + i * shift] - center_x")
-    cg.write("yc[i] = xyz[start_shift + i * shift + 1] - center_y")
-    cg.write("zc[i] = xyz[start_shift + i * shift + 2] - center_z")
+    cg.write("xc[i] = xyz[start_shift + i * xyz_stride] - center_x")
+    cg.write("yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y")
+    cg.write("zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z")
 
     cg.blankline()
     cg.write("// Distance")

--- a/gau2grid/c_generator.py
+++ b/gau2grid/c_generator.py
@@ -342,7 +342,7 @@ def shell_c_generator(cg, L, function_name="", grad=0, cartesian_order="row", in
     if orbital:
         func_sig = "const double* PRAGMA_RESTRICT C, const unsigned long norbitals, "
 
-    func_sig += "const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long shift, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out"
+    func_sig += "const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out"
 
     if orbital:
         func_sig = func_sig.replace("phi_out", "orbital_out")

--- a/gau2grid/c_wrapper.py
+++ b/gau2grid/c_wrapper.py
@@ -19,7 +19,7 @@ cgg = None
 # First check the local folder
 try:
     abs_path = os.path.dirname(os.path.abspath(__file__))
-    cgg = np.ctypeslib.load_library("gg", abs_path)
+    cgg = np.ctypeslib.load_library("libgg", abs_path)
     __libgg_path = os.path.join(abs_path, cgg._name)
     __lib_found = True
 except OSError:
@@ -48,8 +48,9 @@ def _build_collocation_ctype(nout, orbital=False):
 
         # XYZ
         np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),
-        np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),
-        np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),
+        # np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),
+        # np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),
+        ctypes.c_ulong,
 
         # Gaussian
         ctypes.c_int,
@@ -246,15 +247,14 @@ def collocation(xyz,
 
     # Select the correct function
     if grad == 0:
-        cgg.gg_collocation(L, xyz.shape[1], xyz[0], xyz[1], xyz[2], coeffs.shape[0], coeffs, exponents, center,
-                           order_enum, out["PHI"])
+        cgg.gg_collocation(L, npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents, center, order_enum, out["PHI"])
     elif grad == 1:
-        cgg.gg_collocation_deriv1(L, xyz.shape[1], xyz[0], xyz[1], xyz[2], coeffs.shape[0], coeffs, exponents, center,
-                                  order_enum, out["PHI"], out["PHI_X"], out["PHI_Y"], out["PHI_Z"])
+        cgg.gg_collocation_deriv1(L, npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents, center, order_enum,
+                                  out["PHI"], out["PHI_X"], out["PHI_Y"], out["PHI_Z"])
     elif grad == 2:
-        cgg.gg_collocation_deriv2(L, xyz.shape[1], xyz[0], xyz[1], xyz[2], coeffs.shape[0], coeffs, exponents, center,
-                                  order_enum, out["PHI"], out["PHI_X"], out["PHI_Y"], out["PHI_Z"], out["PHI_XX"],
-                                  out["PHI_XY"], out["PHI_XZ"], out["PHI_YY"], out["PHI_YZ"], out["PHI_ZZ"])
+        cgg.gg_collocation_deriv2(L, npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents, center, order_enum,
+                                  out["PHI"], out["PHI_X"], out["PHI_Y"], out["PHI_Z"], out["PHI_XX"], out["PHI_XY"],
+                                  out["PHI_XZ"], out["PHI_YY"], out["PHI_YZ"], out["PHI_ZZ"])
     else:
         raise ValueError("Only up to Hessians's of the points (grad = 2) is supported.")
 
@@ -305,7 +305,7 @@ def orbital(orbs,
     out = utility.validate_coll_output(0, (orbs.shape[0], npoints), out)["PHI"]
 
     # Select the correct function
-    cgg.gg_orbitals(L, orbs, orbs.shape[0], xyz.shape[1], xyz[0], xyz[1], xyz[2], coeffs.shape[0], coeffs, exponents,
+    cgg.gg_orbitals(L, orbs, orbs.shape[0], npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents,
                     center, order_enum, out)
 
     return out

--- a/gau2grid/c_wrapper.py
+++ b/gau2grid/c_wrapper.py
@@ -19,7 +19,7 @@ cgg = None
 # First check the local folder
 try:
     abs_path = os.path.dirname(os.path.abspath(__file__))
-    cgg = np.ctypeslib.load_library("libgg", abs_path)
+    cgg = np.ctypeslib.load_library("gg", abs_path)
     __libgg_path = os.path.join(abs_path, cgg._name)
     __lib_found = True
 except OSError:

--- a/gau2grid/c_wrapper.py
+++ b/gau2grid/c_wrapper.py
@@ -46,13 +46,11 @@ def _build_collocation_ctype(nout, orbital=False):
         ctypes.c_int,
         ctypes.c_ulong,
 
-        # XYZ
+        # XYZ, stride
         np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),
-        # np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),
-        # np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),
         ctypes.c_ulong,
 
-        # Gaussian
+        # Gaussian, nprim, coef, exp, center
         ctypes.c_int,
         np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),  # coef
         np.ctypeslib.ndpointer(dtype=np.double, ndim=1, flags=("C", "A")),  # exp
@@ -128,6 +126,15 @@ def cgg_path():
     return __libgg_path
 
 
+def get_cgg_shared_object():
+    """
+    Returns the compiled C shared object.
+    """
+    _validate_c_import()
+
+    return cgg
+
+
 def max_L():
     """
     Return the maximum compiled angular momentum.
@@ -163,6 +170,7 @@ def _wrapper_checks(L, xyz, spherical, spherical_order, cartesian_order):
     # Check XYZ
     if xyz.shape[0] != 3:
         raise ValueError("XYZ array must be of shape (3, N), found %s" % str(xyz.shape))
+
 
 # Validate the input
     try:
@@ -247,7 +255,8 @@ def collocation(xyz,
 
     # Select the correct function
     if grad == 0:
-        cgg.gg_collocation(L, npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents, center, order_enum, out["PHI"])
+        cgg.gg_collocation(L, npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents, center, order_enum,
+                           out["PHI"])
     elif grad == 1:
         cgg.gg_collocation_deriv1(L, npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents, center, order_enum,
                                   out["PHI"], out["PHI_X"], out["PHI_Y"], out["PHI_Z"])
@@ -305,8 +314,8 @@ def orbital(orbs,
     out = utility.validate_coll_output(0, (orbs.shape[0], npoints), out)["PHI"]
 
     # Select the correct function
-    cgg.gg_orbitals(L, orbs, orbs.shape[0], npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents,
-                    center, order_enum, out)
+    cgg.gg_orbitals(L, orbs, orbs.shape[0], npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents, center,
+                    order_enum, out)
 
     return out
 

--- a/gau2grid/tests/test_c_code.py
+++ b/gau2grid/tests/test_c_code.py
@@ -80,6 +80,35 @@ def test_generator_collocation(basis_name, spherical, order_name):
     # print(gen_results["PHI"])
     th.compare_collocation_results(gen_results, ref_results)
 
+@check_compile
+@pytest.mark.parametrize("xyz_shape", [3, 4, 5])
+def test_generator_collocation_transposed(xyz_shape):
+
+    cgg = gg.get_cgg_shared_object()
+
+    # Collocation data
+    npoints = 20
+    L = 2
+    nelem = 2 * L + 1
+    order_enum = 300
+    coeffs = np.array([2., 1])
+    exponents = np.array([1., 2])
+    center = np.array([0., 0, 0])
+
+    # Generate random points
+    data = np.random.rand(xyz_shape, npoints)
+    xyz = data[:3].copy()
+    xyz_t = data.transpose().copy()
+
+    out = np.zeros((nelem, npoints))
+    out_t = np.zeros((nelem, npoints))
+
+    cgg.gg_collocation(L, npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents, center, order_enum,
+                       out)
+    cgg.gg_collocation(L, npoints, xyz_t.ravel(), xyz_shape, coeffs.shape[0], coeffs, exponents, center, order_enum,
+                       out_t)
+    th.compare_collocation_results({"PHI": out}, {"PHI": out_t})
+
 
 @check_compile
 @pytest.mark.parametrize("basis_name", test_basis_keys)
@@ -117,6 +146,37 @@ def test_generator_orbital(basis_name, spherical, order_name):
     # print(ref_results)
 
     th.compare_collocation_results({"ORBITALS": benchmark}, {"ORBITALS": ref_results})
+
+@check_compile
+@pytest.mark.parametrize("xyz_shape", [3, 4, 5])
+def test_generator_orbital_transposed(xyz_shape):
+
+    cgg = gg.get_cgg_shared_object()
+
+    # Collocation data
+    npoints = 20
+    L = 2
+    nelem = 2 * L + 1
+    order_enum = 300
+    coeffs = np.array([2., 1])
+    exponents = np.array([1., 2])
+    center = np.array([0., 0, 0])
+
+    C = np.random.rand(2, nelem)
+
+    # Generate random points
+    data = np.random.rand(xyz_shape, npoints)
+    xyz = data[:3].copy()
+    xyz_t = data.transpose().copy()
+
+    out = np.zeros((nelem, npoints))
+    out_t = np.zeros((nelem, npoints))
+
+    cgg.gg_orbitals(L, C, C.shape[0], npoints, xyz.ravel(), 1, coeffs.shape[0], coeffs, exponents, center, order_enum,
+                       out)
+    cgg.gg_orbitals(L, C, C.shape[0], npoints, xyz_t.ravel(), xyz_shape, coeffs.shape[0], coeffs, exponents, center, order_enum,
+                       out_t)
+    th.compare_collocation_results({"ORB": out}, {"ORB": out_t})
 
 
 @check_compile

--- a/gau2grid/tests/test_c_code.py
+++ b/gau2grid/tests/test_c_code.py
@@ -87,7 +87,7 @@ def test_generator_collocation_transposed(xyz_shape):
     cgg = gg.get_cgg_shared_object()
 
     # Collocation data
-    npoints = 20
+    npoints = 2000
     L = 2
     nelem = 2 * L + 1
     order_enum = 300
@@ -154,7 +154,7 @@ def test_generator_orbital_transposed(xyz_shape):
     cgg = gg.get_cgg_shared_object()
 
     # Collocation data
-    npoints = 20
+    npoints = 2000
     L = 2
     nelem = 2 * L + 1
     order_enum = 300


### PR DESCRIPTION
The collection and orbital computation C signatures have been changed to the following:

```
      long int xyz_shape = 3;
      double xyz[15] = {0, 0, 0,
                        0, 0, 1,
                        0, 0, 2,
                        0, 0, 3,
                        0, 0, 4}; // xyz, xyz, ... format


      gg_collocation(0,                                // The angular momentum
                     npoints, xyz, xyz_shape,          // Grid data
                     nprim, coef, exp, center, order,  // Gaussian data
                     s_output);                        // Output
```

This allows many different types of packing. This is part of the v2.0 release.