### PR TITLE
windows and clang-cl malloc

### DIFF
--- a/docs/source/c_example.rst
+++ b/docs/source/c_example.rst
@@ -53,7 +53,7 @@ component starts at position ``0``, the ``Y`` component starts at position
 ``5``, and the ``Z`` component starts at position ``10`` as out grid is of
 length ``5``. See :ref:`Gaussian Component Orders <gpo_order>` for more details or order output.
 
-The xyz input shape can either be organized contigously in each dimension like
+The xyz input shape can either be organized contiguously in each dimension like
 the above or packed in a xyz, xyz, ... fashion. If the ``xyz_stride`` is not 1,
 the shape refers to the strides per row. For example, if the data is packed as
 xyzw, xyzw, ... (where w could be a DFT grid weight) the ``xyz_stride`` should

--- a/gau2grid/c_generator.py
+++ b/gau2grid/c_generator.py
@@ -87,7 +87,7 @@ def generate_c_gau2grid(max_L,
     for cgs in [gg_orbital, gg_phi, gg_grad, gg_hess, gg_transform, gg_helper]:
         cgs.write("#include <math.h>")
         # cgs.write("#include <stdio.h>")
-        cgs.write("#if defined __clang__ && defined _MSC_VER")
+        cgs.write("#if defined(__clang__) && defined(_MSC_VER)")
         cgs.write("#include <malloc.h>")
         cgs.write("#elif defined __clang__")
         cgs.write("#include <mm_malloc.h>")

--- a/gau2grid/c_generator.py
+++ b/gau2grid/c_generator.py
@@ -87,7 +87,9 @@ def generate_c_gau2grid(max_L,
     for cgs in [gg_orbital, gg_phi, gg_grad, gg_hess, gg_transform, gg_helper]:
         cgs.write("#include <math.h>")
         # cgs.write("#include <stdio.h>")
-        cgs.write("#if defined __clang__")
+        cgs.write("#if defined __clang__ && defined _MSC_VER")
+        cgs.write("#include <malloc.h>")
+        cgs.write("#elif defined __clang__")
         cgs.write("#include <mm_malloc.h>")
         cgs.write("#elif defined _MSC_VER")
         cgs.write("#include <malloc.h>")

--- a/gau2grid/c_pragma.py
+++ b/gau2grid/c_pragma.py
@@ -19,6 +19,16 @@ _pragma_data = """
     #define PRAGMA_VECTORIZE                                 _Pragma("vector")
     #define PRAGMA_RESTRICT                                  __restrict__
 
+#elif defined(__clang__) && defined(_MSC_VER)
+    // pragmas for MSVC
+
+    #define ALIGNED_MALLOC(alignment, size)                  _aligned_malloc(size, alignment)
+    #define ALIGNED_FREE(ptr)                                _aligned_free(ptr)
+    #define ASSUME_ALIGNED(ptr, width)
+
+    #define PRAGMA_VECTORIZE                                 __pragma(loop(ivdep))
+    #define PRAGMA_RESTRICT                                  __restrict
+    
 #elif defined(__clang__)
     // pragmas for Clang.
     // Do this before GCC because clang also defines __GNUC__


### PR DESCRIPTION
clang-cl + win is misbehaving on psi4. seeing if this is a fix. refinements later

```
-- Build files have been written to: D:/a/1/b/build/external/upstream/libint/libint_external-prefix/src/libint_external-build
[19/41] Performing configure step for 'gau2grid_external'
loading initial cache file D:/a/1/b/build/external/upstream/gau2grid/gau2grid_external-prefix/tmp/gau2grid_external-cache-Debug.cmake
-- The C compiler identification is Clang 7.0.1
-- Check for working C compiler: C:/Program Files/LLVM/bin/clang-cl.exe
-- Check for working C compiler: C:/Program Files/LLVM/bin/clang-cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Setting option MAX_AM: 6
-- Setting option SPHERICAL_ORDER: gaussian
-- Setting option CARTESIAN_ORDER: row
-- Setting option MAX_AM: 6
-- Setting option CMAKE_BUILD_TYPE: Debug
-- Setting option ENABLE_XHOST: OFF
-- Setting option BUILD_FPIC: ON
-- Setting option BUILD_SHARED_LIBS: OFF
-- Setting option ENABLE_GENERIC: OFF
-- Setting option CMAKE_INSTALL_LIBDIR: lib
-- Setting (unspecified) option PYMOD_INSTALL_LIBDIR: /
-- Setting (unspecified) option INSTALL_PYMOD: OFF
-- Setting (unspecified) option NATIVE_PYTHON_INSTALL: OFF
-- gau2grid install: D:/a/1/b/build/stage
-- Found PythonInterp: C:/tools/miniconda3/python.exe (found suitable version "3.6.9", minimum required is "2.7") 
-- Found PythonLibs: C:/tools/miniconda3/libs/Python36.lib
-- Found Python 3.6: C:/tools/miniconda3/python.exe (found version 3.6.9)
-- Configuring done
-- Generating done
-- Build files have been written to: D:/a/1/b/build/external/upstream/gau2grid/gau2grid_external-prefix/src/gau2grid_external-build
[20/41] Performing build step for 'gau2grid_external'
FAILED: external/upstream/gau2grid/gau2grid_external-prefix/src/gau2grid_external-stamp/gau2grid_external-build 
cmd.exe /C "cd /D D:\a\1\b\build\external\upstream\gau2grid\gau2grid_external-prefix\src\gau2grid_external-build && C:\tools\miniconda3\Library\bin\cmake.exe --build . && C:\tools\miniconda3\Library\bin\cmake.exe -E touch D:/a/1/b/build/external/upstream/gau2grid/gau2grid_external-prefix/src/gau2grid_external-stamp/gau2grid_external-build"
[1/8] Generating gau2grid.h, gau2grid_orbital.c, gau2grid_phi.c, gau2grid_deriv1.c, gau2grid_deriv2.c, gau2grid_spherical.c, gau2grid_helper.c
[2/8] Building C object CMakeFiles\gg.dir\gau2grid_phi.c.obj
FAILED: CMakeFiles/gg.dir/gau2grid_phi.c.obj 
C:\PROGRA~1\LLVM\bin\clang-cl.exe  /nologo   /DWIN32 /D_WINDOWS /W3 /MDd /Zi /Ob0 /Od /RTC1   -std=c11 /showIncludes /FoCMakeFiles\gg.dir\gau2grid_phi.c.obj /FdCMakeFiles\gg.dir\gg.pdb -c gau2grid_phi.c
clang-cl.exe: warning: unknown argument ignored in clang-cl: '-std=c11' [-Wunknown-argument]
gau2grid_phi.c(11,10):  fatal error: 'mm_malloc.h' file not found
#include <mm_malloc.h>
         ^~~~~~~~~~~~~
1 error generated.
```