### PR TITLE
version compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ configure_package_config_file(cmake/${PN}Config.cmake.in
                               INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
                                  VERSION ${${PN}_VERSION}
-                                 COMPATIBILITY AnyNewerVersion)
+                                 COMPATIBILITY SameMajorVersion)
 
 # Install our files
 if(${NATIVE_PYTHON_INSTALL_WITH_LIB} OR (NOT(${INSTALL_PYMOD} AND ${NATIVE_PYTHON_INSTALL})))


### PR DESCRIPTION
this will make `find_package(gau2grid 1.2)` not accept a gau2grid 2 that it finds. would have been helpful for psi4.

no urgency, I just remembered to check this, and sure enough, it was wrong.