### PR TITLE
new python

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,6 +4,11 @@ extraction:
   python:  # Configure Python
     python_setup:  # Configure the setup
       version: 3  # Specify Version 3
+  cpp:
+    prepare:
+      packages:
+        - python3-numpy
+
 path_classifiers:
   test:
     - scripts/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
         - gcc-6
     env:
       - C_COMPILER='gcc-6'
-      - PYTHON_VER='3.5'
+      - PYTHON_VER='3.8'
       - BUILD_TYPE='release'
 
   - os: linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ endif()
 message(STATUS "gau2grid install: ${CMAKE_INSTALL_PREFIX}")
 
 #  <<  Python  >>
-set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5)  # adjust with CMake minimum FindPythonInterp
-find_package(PythonLibsNew 2.7 REQUIRED)
+set(Python_ADDITIONAL_VERSIONS 3.8 3.7 3.6 3.5)  # adjust with CMake minimum FindPythonInterp
+find_package(PythonLibsNew 3.6 REQUIRED)
 message(STATUS "${Cyan}Found Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}${ColourReset}: ${PYTHON_EXECUTABLE} (found version ${PYTHON_VERSION_STRING})")
 
 


### PR DESCRIPTION
@susilehtola noticed in the Fedora builds that the current state was picking up Python 2.7 and being generally unhappy.

I don't actually recall what minimum Python g2g was meaning to support, but py36+ is in keeping with many other packages and is not unreasonable wrt the [Py release cycle](https://python-release-cycle.glitch.me).