### PR TITLE
Making gau2grid subprojectable via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,9 @@ message(STATUS "${Cyan}Found Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MIN
 
 ################################  Main Project  ################################
 add_custom_command(
-    OUTPUT  gau2grid.h gau2grid_orbital.c gau2grid_phi.c gau2grid_deriv1.c gau2grid_deriv2.c gau2grid_deriv3.c gau2grid_transform.c gau2grid_helper.c
+    OUTPUT  gau2grid/gau2grid.h gau2grid_orbital.c gau2grid_phi.c gau2grid_deriv1.c gau2grid_deriv2.c gau2grid_deriv3.c gau2grid_transform.c gau2grid_helper.c
     COMMAND ${PYTHON_EXECUTABLE} -c "import sys; \
-                                     sys.path.append('${CMAKE_SOURCE_DIR}'); \
+                                     sys.path.append('${PROJECT_SOURCE_DIR}'); \
                                      import gau2grid as gg; \
                                      gg.c_gen.generate_c_gau2grid(${MAX_AM}, path='${CMAKE_CURRENT_BINARY_DIR}')"
     DEPENDS gau2grid/c_generator.py
@@ -106,7 +106,11 @@ include(CMakePackageConfigHelpers)
 
 set(PN ${PROJECT_NAME})
 
-target_include_directories(gg INTERFACE
+# Alias to allow for consistent manipulation as a subproject
+add_library( ${PN}::gg ALIAS gg )
+
+target_include_directories(gg PUBLIC
+                           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 option_with_default(BUILD_FPIC "Libraries will be compiled with position independent code" ON)
 option_with_print(BUILD_SHARED_LIBS "Build final library as shared, not static" ON)
 option_with_default(ENABLE_GENERIC "Enables mostly static linking of system libraries for shared library" OFF)
+option_with_default(DISABLE_PRAGMA "Disable certain pragma optimizations, appends _GG_NO_PRAGMA to compile flags" OFF )
 
 # Warnings
 if((${BUILD_SHARED_LIBS}) AND NOT ${BUILD_FPIC})
@@ -91,6 +92,10 @@ else()
 endif()
 set_target_properties(gg PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
                                     SOVERSION 2)  # bump whenever interface has changes or removals
+
+if( DISABLE_PRAGMA )
+  target_compile_definitions( gg PRIVATE $<BUILD_INTERFACE:__GG_NO_PRAGMA> )
+endif()
 
 find_package(StandardMathLibraryC)
 target_link_libraries(gg PRIVATE ${STANDARD_MATH_LIBRARY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,8 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.
 
 # Install our files
 if(${NATIVE_PYTHON_INSTALL_WITH_LIB} OR (NOT(${INSTALL_PYMOD} AND ${NATIVE_PYTHON_INSTALL})))
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gau2grid.h
-                  ${CMAKE_CURRENT_BINARY_DIR}/gau2grid_pragma.h
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gau2grid/gau2grid.h
+                  ${CMAKE_CURRENT_BINARY_DIR}/gau2grid/gau2grid_pragma.h
                   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PN})
 
     install(TARGETS gg

--- a/gau2grid/c_generator.py
+++ b/gau2grid/c_generator.py
@@ -268,7 +268,7 @@ def generate_c_gau2grid(max_L,
     gg_header.write("#endif /* GAU2GRID_GUARD_H */")
 
     # Create header directory if not present
-    header_path=os.path.join(path,'gau2grid')
+    header_path = os.path.join(path,"gau2grid")
     if not os.path.isdir(header_path):
         os.mkdir(header_path)
 

--- a/gau2grid/c_generator.py
+++ b/gau2grid/c_generator.py
@@ -99,9 +99,9 @@ def generate_c_gau2grid(max_L,
         cgs.write("#include <stdlib.h>")
         cgs.write("#endif")
         cgs.blankline()
-        cgs.write('#include "gau2grid.h"')
-        cgs.write('#include "gau2grid_utility.h"')
-        cgs.write('#include "gau2grid_pragma.h"')
+        cgs.write('#include "gau2grid/gau2grid.h"')
+        cgs.write('#include "gau2grid/gau2grid_utility.h"')
+        cgs.write('#include "gau2grid/gau2grid_pragma.h"')
         cgs.blankline()
 
     # Header guards
@@ -113,7 +113,7 @@ def generate_c_gau2grid(max_L,
     gg_header.write("#define GAU2GRID_GUARD_H")
     gg_header.blankline()
 
-    gg_header.write('#include "gau2grid_pragma.h"')
+    gg_header.write('#include "gau2grid/gau2grid_pragma.h"')
     gg_header.blankline()
 
     gg_header.write("// Order definitions")
@@ -267,9 +267,14 @@ def generate_c_gau2grid(max_L,
     gg_header.write("#endif")
     gg_header.write("#endif /* GAU2GRID_GUARD_H */")
 
+    # Create header directory if not present
+    header_path=os.path.join(path,'gau2grid')
+    if not os.path.isdir(header_path):
+        os.mkdir(header_path)
+
     # Write out the CG's to files
-    gg_header.repr(filename=os.path.join(path, "gau2grid.h"), clang_format=do_cf)
-    gg_utility_header.repr(filename=os.path.join(path, "gau2grid_utility.h"), clang_format=do_cf)
+    gg_header.repr(filename=os.path.join(header_path, "gau2grid.h"), clang_format=do_cf)
+    gg_utility_header.repr(filename=os.path.join(header_path, "gau2grid_utility.h"), clang_format=do_cf)
     gg_orbital.repr(filename=os.path.join(path, "gau2grid_orbital.c"), clang_format=do_cf)
     gg_phi.repr(filename=os.path.join(path, "gau2grid_phi.c"), clang_format=do_cf)
     gg_grad.repr(filename=os.path.join(path, "gau2grid_deriv1.c"), clang_format=do_cf)
@@ -277,7 +282,7 @@ def generate_c_gau2grid(max_L,
     gg_der3.repr(filename=os.path.join(path, "gau2grid_deriv3.c"), clang_format=do_cf)
     gg_transform.repr(filename=os.path.join(path, "gau2grid_transform.c"), clang_format=do_cf)
     gg_helper.repr(filename=os.path.join(path, "gau2grid_helper.c"), clang_format=do_cf)
-    gg_pragma.repr(filename=os.path.join(path, "gau2grid_pragma.h"))
+    gg_pragma.repr(filename=os.path.join(header_path, "gau2grid_pragma.h"))
 
 
 def shell_c_generator(cg, L, function_name="", grad=0, cartesian_order="row", inner_block="auto", orbital=False):


### PR DESCRIPTION
Addresses #63 

It adds / changes the following 

1. `CMAKE_SOURCE_DIR` -> `PROJECT_SOURCE_DIR` (see #63)
2. Adds a TARGET alias (`gau2grid::gg`) and enforces the local build tree to have the same header directory hierarchy as the installed target to allow for consistent manipulation / linkage of gau2grid both as a subproject and as a discovered target (e.g. `find_package`)
3. Adds an option to toggle the `__GG_NO_PRAGMA` compiler def (needed on e.g. PPC).